### PR TITLE
Fix .gitignore typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
-# python virtual enviorment directory
+# python virtual environment directory
 .venv/
 
 # Visual Studio 2017 auto generated files


### PR DESCRIPTION
## Summary
- fix a typo in the `.gitignore` comment for the Python virtual environment directory

## Testing
- `python -m py_compile Lotto645Analysis.py`


------
https://chatgpt.com/codex/tasks/task_e_683fb3f79db483268f4c3407d12bfd01